### PR TITLE
feat: support timeframe config for binance

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -88,9 +88,11 @@ func executeStartCommand(cmd *cobra.Command, args []string) {
 			}
 
 			mkts[i].ExchangeNames = make(map[string]string, len(wrappers))
+			mkts[i].ExchangeTimeFrames = make(map[string]string, len(wrappers))
 
 			for _, exName := range mkt.Exchanges {
 				mkts[i].ExchangeNames[exName.Name] = exName.MarketName
+				mkts[i].ExchangeTimeFrames[exName.Name] = exName.TimeFrame
 			}
 		}
 		err := strategies.MatchWithMarkets(strategyConf.Strategy, mkts)

--- a/environment/config.go
+++ b/environment/config.go
@@ -46,6 +46,7 @@ type MarketConfig struct {
 type ExchangeBindingsConfig struct {
 	Name       string `yaml:"exchange"`    // Represents the name of the exchange.
 	MarketName string `yaml:"market_name"` // Represents the name of the market as seen from the exchange.
+	TimeFrame  string `yaml:"time_frame"`
 }
 
 // BotConfig contains all config data of the bot, which can be also loaded from config file.

--- a/environment/market.go
+++ b/environment/market.go
@@ -32,10 +32,11 @@ type Ticker struct {
 
 //Market represents the environment the bot is trading in.
 type Market struct {
-	Name           string            `json:"name,required"`            //Represents the name of the market as defined in general (e.g. ETH-BTC).
-	BaseCurrency   string            `json:"baseCurrency,omitempty"`   //Represents the base currency of the market.
-	MarketCurrency string            `json:"marketCurrency,omitempty"` //Represents the currency to exchange by using base currency.
-	ExchangeNames  map[string]string `json:"-"`                        // Represents the various names of the market on various exchanges.
+	Name               string            `json:"name,required"`            //Represents the name of the market as defined in general (e.g. ETH-BTC).
+	BaseCurrency       string            `json:"baseCurrency,omitempty"`   //Represents the base currency of the market.
+	MarketCurrency     string            `json:"marketCurrency,omitempty"` //Represents the currency to exchange by using base currency.
+	ExchangeNames      map[string]string `json:"-"`                        // Represents the various names of the market on various exchanges.
+	ExchangeTimeFrames map[string]string `json:"timeFrame,omitempty"`      // Represents the timeframe to retrieve candles on various exchanges
 }
 
 func (m Market) String() string {

--- a/exchanges/binance.go
+++ b/exchanges/binance.go
@@ -233,7 +233,10 @@ func (wrapper *BinanceWrapper) GetMarketSummary(market *environment.Market) (*en
 // GetCandles gets the candle data from the exchange.
 func (wrapper *BinanceWrapper) GetCandles(market *environment.Market) ([]environment.CandleStick, error) {
 	if !wrapper.websocketOn {
-		binanceCandles, err := wrapper.api.NewKlinesService().Symbol(MarketNameFor(market, wrapper)).Do(context.Background())
+		binanceCandles, err := wrapper.api.NewKlinesService().
+			Symbol(MarketNameFor(market, wrapper)).
+			Interval(MarketTimeFrameFor(market, wrapper)).
+			Do(context.Background())
 		if err != nil {
 			return nil, err
 		}

--- a/exchanges/generic_exchange_wrapper.go
+++ b/exchanges/generic_exchange_wrapper.go
@@ -17,7 +17,6 @@ package exchanges
 
 import (
 	"errors"
-
 	"github.com/saniales/golang-crypto-trading-bot/environment"
 	"github.com/shopspring/decimal"
 )
@@ -32,7 +31,7 @@ const (
 	MakerTrade = "maker"
 )
 
-//ExchangeWrapper provides a generic wrapper for exchange services.
+// ExchangeWrapper provides a generic wrapper for exchange services.
 type ExchangeWrapper interface {
 	Name() string                                                                    // Gets the name of the exchange.
 	GetCandles(market *environment.Market) ([]environment.CandleStick, error)        // Gets the candle data from the exchange.
@@ -63,4 +62,9 @@ var ErrWebsocketNotSupported = errors.New("Cannot use websocket: exchange does n
 // MarketNameFor gets the market name as seen by the exchange.
 func MarketNameFor(m *environment.Market, wrapper ExchangeWrapper) string {
 	return m.ExchangeNames[wrapper.Name()]
+}
+
+// MarketTimeFrameFor gets the market timeframe
+func MarketTimeFrameFor(m *environment.Market, wrapper ExchangeWrapper) string {
+	return m.ExchangeTimeFrames[wrapper.Name()]
 }


### PR DESCRIPTION
While trying to making a bot with binance I found this error occurred
```
<APIError> code=-1105, msg=Parameter 'interval' was empty.
```
Digging deeper into souce code I see that we are missing the `Interval` value when call Binance API. With this PR, the `.bot_config.yaml` file will have extra `time_frame` config like this. For now this ony fixed for `GetCandles` function. We can add more for functions that use KLineServices to get candles data.
```
simulation_mode: true
exchange_configs:
- exchange: binance
  public_key: 
  secret_key: 
  deposit_addresses:
    USDT: 
  fake_balances:
    USDT: 100
strategies:
- strategy: MyStrategy
  markets:
  - market: BTC-USDT
    bindings:
    - exchange: binance
      market_name: BTCUSDT
      time_frame: 4h
```